### PR TITLE
Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-structopt = "0.2.8"
+clap = { version = "3", features = [ "derive", "env" ] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2021"
 clap = { version = "3", features = [ "derive", "env" ] }
 
 [dev-dependencies]
+futures = "0.3.24"
+hyper = { version = "0.14.20", features = ["server", "http2"] }
+tokio = { version = "1.21.0", features = ["macros", "net", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/clap-port-flag"
 description = "Easily add a --port flag to CLIs using Structopt."
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
+edition = "2021"
 
 [dependencies]
 structopt = "0.2.8"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -7,13 +7,13 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
-  #[structopt(flatten)]
-  port: Port,
+    #[structopt(flatten)]
+    port: Port,
 }
 
 fn main() -> Result<(), std::io::Error> {
-  let args = Cli::from_args();
-  let tcp_listener = args.port.bind_or(8080)?;
-  println!("{:?}", tcp_listener);
-  Ok(())
+    let args = Cli::from_args();
+    let tcp_listener = args.port.bind_or(8080)?;
+    println!("{:?}", tcp_listener);
+    Ok(())
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,18 +1,17 @@
 extern crate clap_port_flag;
-#[macro_use]
-extern crate structopt;
 
 use clap_port_flag::Port;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+use clap::Parser;
+
+#[derive(Debug, Parser)]
 struct Cli {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     port: Port,
 }
 
 fn main() -> Result<(), std::io::Error> {
-    let args = Cli::from_args();
+    let args = Cli::parse();
     let tcp_listener = args.port.bind_or(8080)?;
     println!("{:?}", tcp_listener);
     Ok(())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-max_width = 80
-tab_spaces = 2
+# default

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,42 +2,33 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(test, deny(warnings))]
 
-#[macro_use]
-extern crate structopt;
-
 use std::io;
 use std::net::TcpListener;
 use std::os::raw::c_int;
 use std::os::unix::io::FromRawFd;
 
-/// Easily add a `--port` flag to Structopt.
+/// Easily add a `--port` flag to clap.
 ///
 /// ## Usage
 /// ```rust
-/// extern crate clap_port_flag;
-/// #[macro_use] extern crate structopt;
-///
-/// use structopt::StructOpt;
-/// use clap_port_flag::Port;
-///
-/// #[derive(Debug, StructOpt)]
+/// #[derive(Debug, clap::Parser)]
 /// struct Cli {
-///   #[structopt(flatten)]
-///   port: Port,
+///   #[clap(flatten)]
+///   port: clap_port_flag::Port,
 /// }
 /// #
 /// # fn main() {}
 /// ```
-#[derive(StructOpt, Debug)]
+#[derive(clap::Args, Debug)]
 pub struct Port {
     /// The network address to listen to.
-    #[structopt(short = "a", long = "address", default_value = "127.0.0.1")]
+    #[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
     address: String,
     /// The network port to listen to.
-    #[structopt(short = "p", long = "port", env = "PORT", group = "bind")]
+    #[clap(short = 'p', long = "port", env = "PORT", group = "bind")]
     port: Option<u16>,
     /// A previously opened network socket.
-    #[structopt(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
+    #[clap(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
     fd: Option<c_int>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
-#![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
+#![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
 #![cfg_attr(test, deny(warnings))]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,15 @@ use std::os::unix::io::FromRawFd;
 /// ```
 #[derive(StructOpt, Debug)]
 pub struct Port {
-  /// The network address to listen to.
-  #[structopt(short = "a", long = "address", default_value = "127.0.0.1")]
-  address: String,
-  /// The network port to listen to.
-  #[structopt(short = "p", long = "port", env = "PORT", group = "bind")]
-  port: Option<u16>,
-  /// A previously opened network socket.
-  #[structopt(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
-  fd: Option<c_int>,
+    /// The network address to listen to.
+    #[structopt(short = "a", long = "address", default_value = "127.0.0.1")]
+    address: String,
+    /// The network port to listen to.
+    #[structopt(short = "p", long = "port", env = "PORT", group = "bind")]
+    port: Option<u16>,
+    /// A previously opened network socket.
+    #[structopt(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
+    fd: Option<c_int>,
 }
 
 /// Create a TCP socket.
@@ -48,24 +48,23 @@ pub struct Port {
 /// `TcpListener::from_raw_fd()` method, which may panic if a non-existent file
 /// descriptor was passed.
 impl Port {
-  /// Create a TCP socket from the passed in port or file descriptor.
-  pub fn bind(&self) -> std::io::Result<TcpListener> {
-    match self {
-      Self { fd: Some(fd), .. } => unsafe { Ok(TcpListener::from_raw_fd(*fd)) },
-      Self {
-        port: Some(port), ..
-      } => TcpListener::bind((self.address.as_str(), *port)),
-      _ => Err(io::Error::new(io::ErrorKind::Other, "No port supplied.")),
+    /// Create a TCP socket from the passed in port or file descriptor.
+    pub fn bind(&self) -> std::io::Result<TcpListener> {
+        match self {
+            Self { fd: Some(fd), .. } => unsafe { Ok(TcpListener::from_raw_fd(*fd)) },
+            Self {
+                port: Some(port), ..
+            } => TcpListener::bind((self.address.as_str(), *port)),
+            _ => Err(io::Error::new(io::ErrorKind::Other, "No port supplied.")),
+        }
     }
-  }
 
-  /// Create a TCP socket by calling to `.bind()`. If it fails, create a socket
-  /// on `port`.
-  ///
-  /// Useful to create a default socket to listen to if none was passed.
-  pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
-    self
-      .bind()
-      .or_else(|_| TcpListener::bind((self.address.as_str(), port)))
-  }
+    /// Create a TCP socket by calling to `.bind()`. If it fails, create a socket
+    /// on `port`.
+    ///
+    /// Useful to create a default socket to listen to if none was passed.
+    pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
+        self.bind()
+            .or_else(|_| TcpListener::bind((self.address.as_str(), port)))
+    }
 }


### PR DESCRIPTION
Draft as long as #17 is not done.

This PR cleans up the codebase to use clap instead of structopt.