### PR TITLE
Address be addr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
           - 1.60.0
           - stable
           - beta
+        features:
+          - addr_with_port
 
     steps:
       - name: Checkout sources
@@ -33,6 +35,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+      - name: cargo-check-feature-${{ matrix.features }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features ${{ matrix.features }}
+      - name: cargo-check-all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features
 
 
   deny:
@@ -78,6 +90,8 @@ jobs:
           - 1.60.0
           - stable
           - beta
+        features:
+          - addr_with_port
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -88,6 +102,16 @@ jobs:
           override: true
       - uses: swatinem/rust-cache@v1
       - name: cargo-test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all
+      - name: cargo-test-feature-${{ matrix.features }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --features ${{ matrix.features }}
+      - name: cargo-test-all-features
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ clap = { version = "3", features = [ "derive", "env" ] }
 futures = "0.3.24"
 hyper = { version = "0.14.20", features = ["server", "http2"] }
 tokio = { version = "1.21.0", features = ["macros", "net", "rt-multi-thread"] }
+
+[features]
+addr_with_port = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(test, deny(warnings))]
 
-use std::io;
 use std::net::TcpListener;
 use std::os::raw::c_int;
 use std::os::unix::io::FromRawFd;
@@ -21,12 +20,21 @@ use std::os::unix::io::FromRawFd;
 /// ```
 #[derive(clap::Args, Debug)]
 pub struct Port {
+    /// The network address and port to listen to.
+    #[cfg(feature = "addr_with_port")]
+    #[clap(short = 'a', long = "address", default_value = "127.0.0.1:80")]
+    address: std::net::SocketAddr,
+
     /// The network address to listen to.
+    #[cfg(not(feature = "addr_with_port"))]
     #[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
     address: String,
+
     /// The network port to listen to.
+    #[cfg(not(features = "addr_with_port"))]
     #[clap(short = 'p', long = "port", env = "PORT", group = "bind")]
     port: Option<u16>,
+
     /// A previously opened network socket.
     #[clap(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
     fd: Option<c_int>,
@@ -41,12 +49,26 @@ pub struct Port {
 impl Port {
     /// Create a TCP socket from the passed in port or file descriptor.
     pub fn bind(&self) -> std::io::Result<TcpListener> {
-        match self {
-            Self { fd: Some(fd), .. } => unsafe { Ok(TcpListener::from_raw_fd(*fd)) },
-            Self {
-                port: Some(port), ..
-            } => TcpListener::bind((self.address.as_str(), *port)),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "No port supplied.")),
+        if let Some(fd) = self.fd {
+            return unsafe { Ok(TcpListener::from_raw_fd(fd)) };
+        }
+
+        #[cfg(feature = "addr_with_port")]
+        {
+            let addr: std::net::SocketAddr = self.address;
+            TcpListener::bind(addr)
+        }
+        #[cfg(not(feature = "addr_with_port"))]
+        {
+            let addr: &str = self.address.as_str();
+            if let Some(port) = self.port {
+                TcpListener::bind((addr, port))
+            } else {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "No port supplied.",
+                ))
+            }
         }
     }
 
@@ -54,6 +76,19 @@ impl Port {
     /// on `port`.
     ///
     /// Useful to create a default socket to listen to if none was passed.
+    #[cfg(feature = "addr_with_port")]
+    pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
+        let mut addr = self.address;
+        addr.set_port(port);
+
+        self.bind().or_else(|_| TcpListener::bind(addr))
+    }
+
+    /// Create a TCP socket by calling to `.bind()`. If it fails, create a socket
+    /// on `port`.
+    ///
+    /// Useful to create a default socket to listen to if none was passed.
+    #[cfg(not(feature = "addr_with_port"))]
     pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
         self.bind()
             .or_else(|_| TcpListener::bind((self.address.as_str(), port)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ mod tests {
         port: Port,
     }
 
+    #[cfg(not(feature = "addr_with_port"))]
     #[test]
     fn test_cli() {
         let args = Cli::try_parse_from(&["test", "--address", "1.2.3.4", "--port", "1234"]);
@@ -114,5 +115,18 @@ mod tests {
         let args = args.unwrap();
         assert_eq!(args.port.address, "1.2.3.4");
         assert_eq!(args.port.port, Some(1234));
+    }
+
+    #[cfg(feature = "addr_with_port")]
+    #[test]
+    fn test_cli() {
+        let args = Cli::try_parse_from(&["test", "--address", "1.2.3.4:8080"]);
+        assert!(args.is_ok(), "Not ok: {:?}", args.unwrap_err());
+        let args = args.unwrap();
+        let exp = std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
+            std::net::Ipv4Addr::new(1, 2, 3, 4),
+            8080,
+        ));
+        assert_eq!(args.port.address, exp);
     }
 }


### PR DESCRIPTION
Adds a feature whether the `--address` flag can be a `std::net::SocketAddr` (which includes the port).

Feature is OFF by default (to preserve the former behaviour).