### PR TITLE
Feature fd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - beta
         features:
           - addr_with_port
+          - fd
 
     steps:
       - name: Checkout sources
@@ -92,6 +93,7 @@ jobs:
           - beta
         features:
           - addr_with_port
+          - fd
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ hyper = { version = "0.14.20", features = ["server", "http2"] }
 tokio = { version = "1.21.0", features = ["macros", "net", "rt-multi-thread"] }
 
 [features]
+default = ["fd"]
 addr_with_port = []
-
+fd = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,10 @@
 #![cfg_attr(test, deny(warnings))]
 
 use std::net::TcpListener;
+
+#[cfg(feature = "fd")]
 use std::os::raw::c_int;
+#[cfg(feature = "fd")]
 use std::os::unix::io::FromRawFd;
 
 /// Easily add a `--port` flag to clap.
@@ -36,6 +39,7 @@ pub struct Port {
     port: Option<u16>,
 
     /// A previously opened network socket.
+    #[cfg(feature = "fd")]
     #[clap(long = "listen-fd", env = "LISTEN_FD", group = "bind")]
     fd: Option<c_int>,
 }
@@ -46,9 +50,11 @@ pub struct Port {
 /// If a file descriptor was passed directly, we call the unsafe
 /// `TcpListener::from_raw_fd()` method, which may panic if a non-existent file
 /// descriptor was passed.
+/// (This only applies if the "fd" feature is enabled)
 impl Port {
     /// Create a TCP socket from the passed in port or file descriptor.
     pub fn bind(&self) -> std::io::Result<TcpListener> {
+        #[cfg(feature = "fd")]
         if let Some(fd) = self.fd {
             return unsafe { Ok(TcpListener::from_raw_fd(fd)) };
         }


### PR DESCRIPTION
Makes the "TcpSocket from file descriptor" functionality optional, but keeps it by default so that the functionality is the same as before.